### PR TITLE
Upgrade fastutil to 8.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
-            <version>6.5.0</version>
+            <version>8.5.2</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/facebook/hive/orc/IntDictionaryEncoder.java
+++ b/src/main/java/com/facebook/hive/orc/IntDictionaryEncoder.java
@@ -61,7 +61,7 @@ class IntDictionaryEncoder extends DictionaryEncoder {
     }
 
     public int getByteSize() {
-      int size = key.length * 8 + value.length * 4 + used.length;
+      int size = key.length * 8 + value.length * 4;
 
       // If we're close to the point where the dictionary is going to be rehashed, be pessimistic
       // and adjust the size assuming we will

--- a/src/test/java/com/facebook/hive/orc/TestIntDictionaryEncoder.java
+++ b/src/test/java/com/facebook/hive/orc/TestIntDictionaryEncoder.java
@@ -52,7 +52,7 @@ public class TestIntDictionaryEncoder {
   public void test1() throws Exception {
     IntDictionaryEncoder dictEncoder = new IntDictionaryEncoder(false, 4, true);
 
-    assertEquals(98858, dictEncoder.getByteSize());
+    assertEquals(98832, dictEncoder.getByteSize());
     assertEquals(0, dictEncoder.size());
 
     int [] addKeys = new int [] {1, 1, 0, 3, 2, 1, 3, 0, -6, 100};
@@ -74,7 +74,7 @@ public class TestIntDictionaryEncoder {
     }
     checkContent(dictEncoder, expectedUniqueValues, expectedOrder);
     dictEncoder.clear();
-    assertEquals(98858, dictEncoder.getByteSize());
+    assertEquals(98832, dictEncoder.getByteSize());
     assertEquals(0, dictEncoder.size());
     checkContent(dictEncoder, new int[0], new int[0]);
   }
@@ -85,7 +85,7 @@ public class TestIntDictionaryEncoder {
       new IntDictionaryEncoder(true, 4 , true) };
 
     for (IntDictionaryEncoder dictEncoder : encoders) {
-      assertEquals(98858, dictEncoder.getByteSize());
+      assertEquals(98832, dictEncoder.getByteSize());
       assertEquals(0, dictEncoder.size());
 
       int [] addKeys = new int [] {1, 1, 0, 3, 2, 1, 3, 0, -6, 100};
@@ -102,7 +102,7 @@ public class TestIntDictionaryEncoder {
 
       checkContent(dictEncoder, expectedOrderedUniqueValues, expectedOrder);
       dictEncoder.clear();
-      assertEquals(98858, dictEncoder.getByteSize());
+      assertEquals(98832, dictEncoder.getByteSize());
       assertEquals(0, dictEncoder.size());
       checkContent(dictEncoder, new int[0], new int[0]);
     }


### PR DESCRIPTION
For introducing integer dictionary encoding in presto-orc module,
I require latest version of fastutil. When I upgraded the fastutil
the presto-orc tests are broken due to 'used' being removed from
the newer versions. Fixed the code for the latest version.

Fixed the broken tests.