### PR TITLE
Fix for CVE-2024-36124 . Upgrading snappy version to 0.5. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.iq80.snappy</groupId>
             <artifactId>snappy</artifactId>
-            <version>0.2</version>
+            <version>0.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR is for upgrading the snappy version from 0.2 to 0.5 as the version 0.2 has a security vulnerability. Upgrading this version to 0.5 fixes the CVE-2024-36124. 